### PR TITLE
prevents accidental publishing in bower and npm

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "metrics-graphics",
   "version": "2.4.0",
+  "private": true,
   "main": [
     "dist/metricsgraphics.js",
     "dist/metricsgraphics.css"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.4.0",
   "description": "A library optimized for concise, principled data graphics and layouts",
   "main": "dist/metricsgraphics.js",
+  "private": true,
   "scripts": {
     "build": "gulp build:js",
     "test": "gulp test",


### PR DESCRIPTION
we don't want to collide with the original metrics-graphics library
